### PR TITLE
Remove data merging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The following options are supported:
 - `idField` (default: `id`): The id property field of your services
 - `dataField` (default: `data`): The data property field in paginated responses
 - `listStrategy` (default: `smart`): The strategy to use for streaming the data. Can be `smart`, `always` or `never`
-- `merge` (`function(current, data){}`): A function that merges the current and new data
 - `sorter` (`function(query, options) {}`): A function that returns a sorting function for the given query and option including pagination and limiting. Does not need to be customized unless there is a sorting mechanism other than Feathers standard in place.
 - `matcher` (`function(query)`): A function that returns a function which returns whether an item matches the original query or not.
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,7 @@ function FeathersRx(Rx, options) {
     sorter: makeSorter,
     matcher,
     // Whether to requery service when a change is detected
-    listStrategy: 'smart',
-    // The merging strategy
-    merge(current, eventData) {
-      return Object.assign({}, current, eventData);
-    }
+    listStrategy: 'smart'
   }, options);
 
   if(typeof options.listStrategy === 'string') {

--- a/src/resource.js
+++ b/src/resource.js
@@ -28,19 +28,17 @@ export default function(Rx, events, settings, method) {
       const filteredRemoves = events.removed.filter(filter);
       // `created`, `updated` and `patched`
       const filteredEvents = Rx.Observable.merge(
-          events.created,
-          events.updated,
-          events.patched
-        ).filter(filter);
+        events.created,
+        events.updated,
+        events.patched
+      ).filter(filter);
 
       return Rx.Observable.merge(
         // Map to a callback that merges old and new data
-        filteredEvents.map(newItem =>
-          oldItem => options.merge(oldItem, newItem)
-        ),
+        filteredEvents,
         // filtered `removed` events always map to a function that returns `null`
-        filteredRemoves.map(() => () => null)
-      ).scan((current, callback) => callback(current), data);
+        filteredRemoves.map(() => null)
+      );
     }));
 
     return promisify(stream, result);

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -126,7 +126,7 @@ describe('reactive lists', () => {
       service.find().first().subscribe(messages => {
         assert.deepEqual(messages, [ { text: 'A test message', [id]: 0 } ]);
         done();
-      });
+      }, done);
     });
 
     it('queries on subscription rather than creation', done => {
@@ -141,7 +141,7 @@ describe('reactive lists', () => {
           assert.deepEqual(messages, [ { text: 'A test message', [id]: 0 } ]);
 
           done();
-        });
+        }, done);
 
       setTimeout(() => {
         assert.equal(result, undefined);
@@ -156,7 +156,7 @@ describe('reactive lists', () => {
           { text: 'Another message', [id]: 1 }
         ]);
         done();
-      });
+      }, done);
 
       setTimeout(() => service.create({ text: 'Another message' }), 20);
     });
@@ -167,7 +167,7 @@ describe('reactive lists', () => {
           { text: 'An updated test message', [id]: 0 }
         ]);
         done();
-      });
+      }, done);
 
       setTimeout(() => service.update(0, { text: 'An updated test message' }), 20);
     });
@@ -178,7 +178,7 @@ describe('reactive lists', () => {
           { text: 'A patched test message', [id]: 0 }
         ]);
         done();
-      });
+      }, done);
 
       setTimeout(() => service.patch(0, { text: 'A patched test message' }), 20);
     });
@@ -187,7 +187,7 @@ describe('reactive lists', () => {
       service.find().skip(1).subscribe(messages => {
         assert.deepEqual(messages, []);
         done();
-      });
+      }, done);
 
       setTimeout(() => service.remove(0), 20);
     });
@@ -195,7 +195,7 @@ describe('reactive lists', () => {
     it('.find with .create that matches', done => {
       const result = service.find({ query: { counter: 1 } });
 
-      result.first().subscribe(messages => assert.deepEqual(messages, []));
+      result.first().subscribe(messages => assert.deepEqual(messages, []), done);
 
       result.skip(1).subscribe(messages => {
         assert.deepEqual(messages, [{
@@ -204,7 +204,7 @@ describe('reactive lists', () => {
           counter: 1
         }]);
         done();
-      });
+      }, done);
 
       setTimeout(() => {
         service.create([{
@@ -263,8 +263,8 @@ describe('reactive lists', () => {
         const result = service.find({ query: { counter: 1 } });
 
         result.first().subscribe(messages =>
-          assert.deepEqual(messages, createdMessages)
-        );
+          assert.deepEqual(messages, createdMessages),
+        done);
 
         result.skip(1).subscribe(messages => {
           assert.deepEqual(messages, [{
@@ -273,7 +273,7 @@ describe('reactive lists', () => {
             [id]: 2
           }]);
           done();
-        });
+        }, done);
 
         setTimeout(() => {
           service.patch(1, { counter: 2 });
@@ -289,8 +289,8 @@ describe('reactive lists', () => {
         const result = service.find({ query: { counter: 1 } });
 
         result.first().subscribe(messages =>
-          assert.deepEqual(messages, createdMessages)
-        );
+          assert.deepEqual(messages, createdMessages),
+        done);
 
         result.skip(2).subscribe(messages => {
           assert.deepEqual(messages, [{
@@ -303,7 +303,7 @@ describe('reactive lists', () => {
             [id]: 2
           }]);
           done();
-        });
+        }, done);
 
         setTimeout(() => {
           service.patch(1, { counter: 2 }).then(

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -73,14 +73,14 @@ describe('reactive resources', () => {
       service.get(id).then(message => {
         assert.deepEqual(message, { [customId]: id, text: 'A test message' });
         done();
-      });
+      }, done);
     });
 
     it('.get as an observable', done => {
       service.get(id).first().subscribe(message => {
         assert.deepEqual(message, { [customId]: id, text: 'A test message' });
         done();
-      });
+      }, done);
     });
 
     it('.update and .patch update existing stream', done => {
@@ -89,21 +89,21 @@ describe('reactive resources', () => {
       result.first().subscribe(message => {
         assert.deepEqual(message, { [customId]: id, text: 'A test message' });
         service.update(id, { text: 'Updated', prop: true });
-      });
+      }, done);
 
       result.skip(1).first().subscribe(message => {
         assert.deepEqual(message, {
           [customId]: id, text: 'Updated', prop: true
         });
         service.patch(id, { text: 'Updated again' });
-      });
+      }, done);
 
       result.skip(2).first().subscribe(message => {
         assert.deepEqual(message, {
           [customId]: id, text: 'Updated again', prop: true
         });
         done();
-      });
+      }, done);
     });
 
     it('.remove emits null', done => {
@@ -113,7 +113,7 @@ describe('reactive resources', () => {
         } else {
           assert.deepEqual(message, { [customId]: id, text: 'A test message' });
         }
-      });
+      }, done);
 
       service.remove(id);
     });


### PR DESCRIPTION
I think the `merge` option is not really necessary since real-time events should dispatch the actual data the app should see and it wasn't even used in `find` streams.

Closes #19