### PR TITLE
Test and fix for find being called only once

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -4,28 +4,39 @@ export default function(Rx, events, settings) {
   return function (params = {}) {
     const query = Object.assign({}, params.query);
     const args = arguments;
-
     const __super = this._super;
 
-    let result;
+    let result = null;
 
     const source = Rx.Observable.create(observer => {
       const _observer = observer;
 
-      result = __super.apply(this, arguments)
-        .then(res => {
-          _observer.next(res);
-          _observer.complete();
-        })
-        .catch(e => _observer.error(e));
+      if(!result) {
+        result = __super.apply(this, arguments);
+
+        // Hack because feathers-query-params deletes stuff from `params.query`
+        // Will be fixed in the next version
+        params.query = query;
+      }
+
+      result.then(res => {
+        _observer.next(res);
+        _observer.complete();
+      })
+      .catch(e => _observer.error(e));
     });
 
-    // Hack because feathers-query-params deletes stuff from `params.query`
-    // Will be fixed in the next version
-    params.query = query;
-
     const options = getOptions(settings, this._rx, params.rx);
+    const promiseWrapper = {
+      then(... args) {
+        return source.toPromise().then(... args);
+      },
 
-    return promisify(options.listStrategy.call(this, source, events, options, args), source.toPromise());
+      catch(... args) {
+        return source.toPromise().catch(... args);
+      }
+    };
+
+    return promisify(options.listStrategy.call(this, source, events, options, args), promiseWrapper);
   };
 }

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -115,6 +115,23 @@ describe('reactive lists', () => {
   });
 
   function baseTests (id) {
+    it('.find is only called once', done => {
+      let counter = 0;
+
+      app.use('/test', {
+        find() {
+          counter++;
+          return Promise.resolve([]);
+        }
+      });
+
+      app.service('test').find().take(1).subscribe(data => {
+        assert.equal(counter, 1);
+        assert.deepEqual(data, []);
+        done();
+      }, done);
+    });
+
     it('.find is promise compatible', done => {
       service.find().then(messages => {
         assert.deepEqual(messages, [ { text: 'A test message', [id]: 0 } ]);
@@ -135,10 +152,13 @@ describe('reactive lists', () => {
       let result;
 
       service.find()
-        .delayWhen(() => Rx.Observable.of(0), trigger$) // delay subscription until trigger$ emits
+        // delay subscription until trigger$ emits
+        .delayWhen(() => Rx.Observable.of(0), trigger$)
         .subscribe(messages => {
           result = messages;
-          assert.deepEqual(messages, [ { text: 'A test message', [id]: 0 } ]);
+          assert.deepEqual(messages, [
+            { text: 'A test message', [id]: 0 }
+          ]);
 
           done();
         }, done);


### PR DESCRIPTION
This pull request makes sure that `find` is only called once (and then cached).

Closes #29, related to #20