### PR TITLE
Smart list strategy updates paginated metadata

### DIFF
--- a/src/strategies.js
+++ b/src/strategies.js
@@ -21,8 +21,7 @@ export default function(Rx) {
           events.updated,
           events.patched
         ).flatMap(() => {
-          const result = _super(...args);
-          const source = Rx.Observable.fromPromise(result);
+          const source = Rx.Observable.fromPromise(_super(...args));
 
           return source.map(sortAndTrim);
         })
@@ -37,21 +36,59 @@ export default function(Rx) {
       // A function that sorts a limits a result (paginated or not)
       const sortAndTrim = options.sorter(query, options);
       const onCreated = eventData => {
-        return items => {
-          const result = items.concat(eventData);
-          // result.total = 1;
-          return result;
+        return page => {
+          const isPaginated = !!page[options.dataField];
+          const process = data => data.concat(eventData);
+
+          if(isPaginated) {
+            return Object.assign({}, page, {
+              total: page.total + 1,
+              [options.dataField]: process(page[options.dataField])
+            });
+          }
+
+          return process(page);
         };
       };
       const onRemoved = eventData => {
-        return items => items.filter(current =>
-          eventData[options.idField] !== current[options.idField]
-        );
+        return page => {
+          const isPaginated = !!page[options.dataField];
+          const process = data => data.filter(current =>
+            eventData[options.idField] !== current[options.idField]
+          );
+
+          if(isPaginated) {
+            return Object.assign({}, page, {
+              total: matches(eventData) ? page.total - 1 : page.total,
+              [options.dataField]: process(page[options.dataField])
+            });
+          }
+
+          return process(page);
+        };
       };
       const onUpdated = eventData => {
-        return items => items.filter(current =>
-          eventData[options.idField] !== current[options.idField]
-        ).concat(eventData).filter(matches);
+        return page => {
+          const isPaginated = !!page[options.dataField];
+          const length = isPaginated ? page[options.dataField].length :
+            page.length;
+          const process = data =>
+            data.filter(current =>
+              eventData[options.idField] !== current[options.idField]
+            ).concat(eventData).filter(matches);
+
+          if(isPaginated) {
+            const processed = process(page[options.dataField]);
+            return Object.assign({}, page, {
+              // Total can be either decreased or increased based
+              // on if the update removed or added the item to the list
+              total: page.total - (length - processed.length),
+              [options.dataField]: processed
+            });
+          }
+
+          return process(page);
+        };
       };
 
       return source.concat(source.exhaustMap(data =>
@@ -59,15 +96,7 @@ export default function(Rx) {
           events.created.filter(matches).map(onCreated),
           events.removed.map(onRemoved),
           Rx.Observable.merge(events.updated, events.patched).map(onUpdated)
-        ).scan((current, callback) => {
-          const isPaginated = !!current[options.dataField];
-          if (isPaginated) {
-            current[options.dataField] = callback(current[options.dataField]);
-          } else {
-            current = callback(current);
-          }
-          return sortAndTrim(current);
-        }, data)
+        ).scan((current, callback) => sortAndTrim(callback(current)), data)
       ));
     }
   };


### PR DESCRIPTION
This pull request makes sure that the `total` in paginated metadata is updated when items are removed, created and updated.

Closes #24