### PR TITLE
add mixin.watch() workaround for firefox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,13 @@ function FeathersRx (options = {}) {
     // get the extended service object
     const newService = service.mixin(mixin);
 
+    // workaround for Firefox
+    // FF defines Object.prototype.watch(), so uberproto doesn't recognize the mixin's .watch()
+    // see https://github.com/feathersjs/feathers-reactive/issues/67
+    if (Object.prototype.watch && Object.prototype.watch === newService.watch) {
+      newService.watch = mixin.watch;
+    }
+    
     // bind the new service to all reactive methods
     for (let method in reactiveMethods) {
       reactiveMethods[method] = reactiveMethods[method].bind(newService);


### PR DESCRIPTION
closes #67 