### PR TITLE
[typings] make Service and ReactiveService generic types default to any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,11 +23,11 @@ declare namespace FeathersReactive {
 }
 
 declare module 'feathers' {
-  interface Service<T> {
+  interface Service<T extends any> {
     watch(): ReactiveService<T>
   }
 
-  interface ReactiveService<T> {
+  interface ReactiveService<T extends any> {
     /**
      * Retrieves a list of all resources from the service.
      * Provider parameters will be passed as params.query


### PR DESCRIPTION
make Service and ReactiveService generic types default to any

needs https://github.com/feathersjs/feathers-hooks/pull/168 and https://github.com/feathersjs/feathers/pull/681